### PR TITLE
Clarify HIIT workouts and add phased progression

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,9 +90,9 @@
     }
   </script>
   -->
-  <script type="module" src="src/js/plan.js?v=1"></script>
+  <script type="module" src="src/js/plan.js?v=2"></script>
   <script type="module" src="src/js/storage.js?v=1"></script>
-  <script type="module" src="src/js/hiit.js?v=2"></script>
+  <script type="module" src="src/js/hiit.js?v=3"></script>
   <script type="module" src="src/js/app.js?v=2"></script>
 </body>
 </html>

--- a/src/js/hiit.js
+++ b/src/js/hiit.js
@@ -2,11 +2,12 @@
 const $ = (s, el=document) => el.querySelector(s);
 
 const templates = [
-  { name:'Greenfield 30/90', build:(pool)=> ({desc:'Ben Greenfield style engine work', mono: pool(1), rounds:10, on:30, off:90}) },
-  { name:'Philly EMOM', build:(pool)=> ({desc:'Marcus Philly inspired EMOM', work:[{m:pool(1),reps:'8–12'},{m:pool(1),reps:'8–12'}], rounds:10, emom:true}) },
-  { name:'Chek Pyramid', build:(pool)=> ({desc:'Paul Chek primal pyramid', chipper:[pool(1),pool(1),pool(1)], scheme:'1‑2‑3‑4‑5‑4‑3‑2‑1'}) },
-  { name:'Classic Chipper', build:(pool)=> ({desc:'For time chipper', chipper:[pool(1),pool(1),pool(1),pool(1)], scheme:'50‑40‑30‑20'}) },
-  { name:'21‑15‑9 WOD', build:(pool)=> ({desc:'CrossFit 21‑15‑9 for time', items:[{m:pool(1),reps:'21'},{m:pool(1),reps:'15'},{m:pool(1),reps:'9'}], rft:1}) }
+  { name:'Greenfield 30/90', build:(pool)=> ({type:'Intervals', desc:'Ben Greenfield style engine work', mono: pool(1), rounds:10, on:30, off:90, cap:20}) },
+  { name:'Philly EMOM',       build:(pool)=> ({type:'EMOM', desc:'Marcus Philly inspired EMOM', work:[{m:pool(1),reps:'8–12'},{m:pool(1),reps:'8–12'}], rounds:10, emom:true, cap:10}) },
+  { name:'Chek Pyramid',      build:(pool)=> ({type:'For quality', desc:'Paul Chek primal pyramid', chipper:[pool(1),pool(1),pool(1)], scheme:'1‑2‑3‑4‑5‑4‑3‑2‑1'}) },
+  { name:'Classic Chipper',   build:(pool)=> ({type:'For time', desc:'For time chipper', chipper:[pool(1),pool(1),pool(1),pool(1)], scheme:'50‑40‑30‑20', cap:20}) },
+  { name:'21‑15‑9 WOD',       build:(pool)=> ({type:'For time', desc:'CrossFit 21‑15‑9 for time', items:[{m:pool(1),reps:'21'},{m:pool(1),reps:'15'},{m:pool(1),reps:'9'}], rft:1, cap:10}) },
+  { name:'12‑min AMRAP',      build:(pool)=> ({type:'AMRAP', desc:'CrossFit style AMRAP', items:[{m:pool(1),reps:'12'},{m:pool(1),reps:'12'},{m:pool(1),reps:'12'}], amrap:12, cap:12}) }
 ];
 
 function movementPool(){
@@ -35,11 +36,13 @@ function generateHIIT(){
   card.innerHTML = `<div class="sec-title">Random HIIT — ${out.name}</div><div class="muted">${out.desc||''}</div>`;
   const ul = document.createElement('ul');
   const add = x => { const li=document.createElement('li'); li.textContent=x; ul.appendChild(li); };
+  if(out.type){ add(`${out.type}${out.cap?` — Cap ${out.cap} min`:''}`); }
   if(out.mono){ add(`${out.mono} — ${out.rounds}× ${out.on}s ON / ${out.off}s EASY`); }
-  if(out.work){ out.work.forEach(w=> add(`${w.m} — ${w.reps}`)); add(`Rounds: ${out.rounds}`); }
-  if(out.emom){ add('EMOM: alternate the two lines above'); }
+  if(out.work){ out.work.forEach(w=> add(`${w.m} — ${w.reps}`)); add(`Rounds: ${out.rounds}`); add('EMOM: alternate the two lines above'); }
   if(out.chipper){ add(`Chipper: ${out.chipper.join(' + ')}`); add(`Scheme: ${out.scheme}`); }
-  if(out.items){ out.items.forEach(it=> add(`${it.m} — ${it.reps}`)); add(`Rounds: ${out.rft}`); }
+  if(out.items && out.rft){ out.items.forEach(it=> add(`${it.m} — ${it.reps}`)); add(`Rounds for time: ${out.rft}`); }
+  if(out.items && out.amrap){ add(`AMRAP ${out.amrap} min:`); out.items.forEach(it=> add(`${it.m} — ${it.reps}`)); }
+  add('Scale load and reps as needed.');
   card.appendChild(ul); el.appendChild(card); window.scrollTo({top:document.body.scrollHeight,behavior:'smooth'});
 }
 

--- a/src/js/plan.js
+++ b/src/js/plan.js
@@ -1,36 +1,76 @@
 // src/js/plan.js
-export const BASE = {
-  D1: [
-    { name: "Front Squat",   variant: "barbell", sets: 4, reps: "6–8", rest: "120s", group:"A", equipment:"barbell", slug:"front-squat" },
-    { name: "Romanian Deadlift", variant: "barbell", sets: 3, reps: "8–10", rest: "90s", group:"B", equipment:"barbell", slug:"romanian-deadlift" },
-    { name: "Walking Lunge", variant: "db/kb", sets: 3, reps: "10/leg", rest: "60–90s", equipment:"dumbbell", slug:"lunge" },
-    { name: "Calf Raise",    variant: "standing", sets: 3, reps: "12–15", rest: "45–60s", equipment:"machine", slug:"calf-raise"}
-  ],
-  D2: [
-    { name: "Pull-ups/Inverted Rows", variant:"as able", sets: 4, reps:"6–10", rest:"90s", equipment:"bar", slug:"pull-up"},
-    { name: "DB Bench/Push-ups", variant:"db/bench", sets: 4, reps:"8–12", rest:"90s", equipment:"bench", slug:"db-bench-press"},
-    { name: "Single-arm Row",  variant:"db/kb", sets: 3, reps:"10/side", rest:"60–90s", equipment:"dumbbell", slug:"one-arm-row"},
-    { name: "Face Pull",       variant:"cable/band", sets: 3, reps:"12–15", rest:"45–60s", equipment:"cable", slug:"face-pull"}
-  ],
-  D3: [ // HIIT/Con
-    { name:"Assault Bike",  variant:"30/90",  sets:"8–12", reps:"30s on", rest:"90s", equipment:"airbike", slug:"air-bike" },
-    { name:"SkiErg/Row",    variant:"alt.",   sets:"8–12", reps:"30s on", rest:"90s", equipment:"skierg", slug:"ski-erg" },
-    { name:"Battle Ropes",  variant:"waves",  sets:"8–12", reps:"30s on", rest:"90s", equipment:"ropes", slug:"battle-ropes" },
-    { name:"Wall Ball",     variant:"20/14#", sets:"8–12", reps:"15–20",  rest:"90s", equipment:"wallball", slug:"wall-ball" }
-  ],
-  D4: [
-    { name:"Hang Power Clean", variant:"barbell", sets:5, reps:"3–5", rest:"120s", equipment:"barbell", slug:"hang-power-clean" },
-    { name:"Push Press",       variant:"barbell", sets:4, reps:"4–6", rest:"120s", equipment:"barbell", slug:"push-press" },
-    { name:"KB Swing",         variant:"hardstyle", sets:3, reps:"15", rest:"60–90s", equipment:"kb", slug:"kettlebell-swing" },
-    { name:"Farmer Carry",     variant:"heavy", sets:3, reps:"30–40m", rest:"60–90s", equipment:"kb", slug:"farmer-carry" }
-  ]
+
+export const PHASES = {
+  1: {
+    D1: [
+      { name: "Front Squat",   variant: "barbell", sets: 4, reps: "6–8", rest: "120s", group:"A", equipment:"barbell", slug:"front-squat" },
+      { name: "Romanian Deadlift", variant: "barbell", sets: 3, reps: "8–10", rest: "90s", group:"B", equipment:"barbell", slug:"romanian-deadlift" },
+      { name: "Walking Lunge", variant: "db/kb", sets: 3, reps: "10/leg", rest: "60–90s", equipment:"dumbbell", slug:"lunge" },
+      { name: "Calf Raise",    variant: "standing", sets: 3, reps: "12–15", rest: "45–60s", equipment:"machine", slug:"calf-raise" }
+    ],
+    D2: [
+      { name: "Pull-ups/Inverted Rows", variant:"as able", sets: 4, reps:"6–10", rest:"90s", equipment:"bar", slug:"pull-up"},
+      { name: "DB Bench/Push-ups", variant:"db/bench", sets: 4, reps:"8–12", rest:"90s", equipment:"bench", slug:"db-bench-press"},
+      { name: "Single-arm Row",  variant:"db/kb", sets: 3, reps:"10/side", rest:"60–90s", equipment:"dumbbell", slug:"one-arm-row"},
+      { name: "Face Pull",       variant:"cable/band", sets: 3, reps:"12–15", rest:"45–60s", equipment:"cable", slug:"face-pull"}
+    ],
+    D3: [],
+    D4: [
+      { name:"Hang Power Clean", variant:"barbell", sets:5, reps:"3–5", rest:"120s", equipment:"barbell", slug:"hang-power-clean"},
+      { name:"Push Press",       variant:"barbell", sets:4, reps:"4–6", rest:"120s", equipment:"barbell", slug:"push-press" },
+      { name:"KB Swing",         variant:"hardstyle", sets:3, reps:"15", rest:"60–90s", equipment:"kb", slug:"kettlebell-swing" },
+      { name:"Farmer Carry",     variant:"heavy", sets:3, reps:"30–40m", rest:"60–90s", equipment:"kb", slug:"farmer-carry" }
+    ]
+  },
+  2: {
+    D1: [
+      { name: "Back Squat",   variant:"barbell", sets:4, reps:"5–6", rest:"120s", group:"A", equipment:"barbell", slug:"back-squat" },
+      { name: "Deadlift",      variant:"barbell", sets:3, reps:"5–6", rest:"120s", group:"B", equipment:"barbell", slug:"deadlift" },
+      { name: "Reverse Lunge", variant:"db/kb", sets:3, reps:"8/leg", rest:"60–90s", equipment:"dumbbell", slug:"reverse-lunge" },
+      { name: "Seated Calf Raise", variant:"machine", sets:3, reps:"10–12", rest:"45–60s", equipment:"machine", slug:"calf-raise" }
+    ],
+    D2: [
+      { name: "Weighted Pull-up/Chin-up", variant:"as able", sets:4, reps:"5–8", rest:"90s", equipment:"bar", slug:"pull-up" },
+      { name: "Barbell Bench Press",      variant:"barbell", sets:4, reps:"6–8", rest:"120s", equipment:"barbell", slug:"bench-press" },
+      { name: "Bent-over Row",            variant:"barbell", sets:3, reps:"8–10", rest:"90s", equipment:"barbell", slug:"row" },
+      { name: "Band Pull-apart",          variant:"band", sets:3, reps:"15–20", rest:"45–60s", equipment:"band", slug:"band-pull-apart" }
+    ],
+    D3: [],
+    D4: [
+      { name:"Power Clean",  variant:"from floor", sets:5, reps:"3",   rest:"120s", equipment:"barbell", slug:"power-clean" },
+      { name:"Push Jerk",    variant:"barbell",    sets:4, reps:"3–5", rest:"120s", equipment:"barbell", slug:"push-jerk" },
+      { name:"KB Swing",     variant:"heavy",      sets:3, reps:"12",  rest:"60–90s", equipment:"kb", slug:"kettlebell-swing" },
+      { name:"Farmer Carry", variant:"longer",     sets:3, reps:"40–50m", rest:"60–90s", equipment:"kb", slug:"farmer-carry" }
+    ]
+  },
+  3: {
+    D1: [
+      { name: "Pause Front Squat", variant:"3s pause", sets:4, reps:"3–5", rest:"120s", group:"A", equipment:"barbell", slug:"front-squat" },
+      { name: "Deadlift",          variant:"heavy",    sets:3, reps:"3–5", rest:"150s", group:"B", equipment:"barbell", slug:"deadlift" },
+      { name: "Bulgarian Split Squat", variant:"db/kb", sets:3, reps:"8/leg", rest:"60–90s", equipment:"dumbbell", slug:"rfess" },
+      { name: "Calf Raise",        variant:"heavy",   sets:3, reps:"8–10", rest:"60s",   equipment:"machine",  slug:"calf-raise" }
+    ],
+    D2: [
+      { name: "Weighted Pull-up",     variant:"heavy", sets:4, reps:"4–6", rest:"120s", equipment:"bar", slug:"pull-up" },
+      { name: "Barbell Bench Press",  variant:"heavy", sets:4, reps:"4–6", rest:"120s", equipment:"barbell", slug:"bench-press" },
+      { name: "Pendlay Row",          variant:"barbell", sets:3, reps:"6–8", rest:"90s", equipment:"barbell", slug:"row" },
+      { name: "Face Pull",            variant:"cable/band", sets:3, reps:"12–15", rest:"45–60s", equipment:"cable", slug:"face-pull" }
+    ],
+    D3: [],
+    D4: [
+      { name:"Clean & Jerk",  variant:"barbell", sets:5, reps:"2–3", rest:"150s", equipment:"barbell", slug:"clean-and-jerk" },
+      { name:"Push Press",    variant:"heavy",   sets:4, reps:"3–5", rest:"120s", equipment:"barbell", slug:"push-press" },
+      { name:"KB Snatch",     variant:"alt.",   sets:3, reps:"10/arm", rest:"60–90s", equipment:"kb", slug:"kettlebell-snatch" },
+      { name:"Farmer Carry",  variant:"heavy",   sets:3, reps:"30–40m", rest:"60–90s", equipment:"kb", slug:"farmer-carry" }
+    ]
+  }
 };
 
 // week modifiers: % intensity change or set tweaks
 const WEEK_TUNING = {
   1:{vol:1.00}, 2:{vol:1.05}, 3:{vol:1.10}, 4:{vol:0.85}, // deload
   5:{vol:1.05}, 6:{vol:1.10}, 7:{vol:1.15}, 8:{vol:0.90}, // deload
-  9:{vol:1.10}, 10:{vol:1.15}, 11:{vol:1.20}, 12:{vol:0.95, note:"test/peak"}
+  9:{vol:1.10}, 10:{vol:1.15}, 11:{vol:1.20}, 12:{vol:0.95, note:"test/peak"},
 };
 
 // Expand reps strings like "6–8" toward the top of range as volume↑
@@ -47,9 +87,11 @@ export function buildPlan(){
   const plan = {};
   for(let w=1; w<=12; w++){
     const t = WEEK_TUNING[w] || {vol:1};
+    const phase = w<=4 ? 1 : w<=8 ? 2 : 3;
     plan[w] = {};
     ["D1","D2","D3","D4"].forEach(day=>{
-      plan[w][day] = BASE[day].map(x => ({
+      const base = PHASES[phase][day] || [];
+      plan[w][day] = base.map(x => ({
         ...x,
         reps: typeof x.reps === "string" ? tweakReps(x.reps, t.vol) : x.reps,
         note: t.note || ""


### PR DESCRIPTION
## Summary
- Structure a 12-week plan into three progressive phases with distinct movement variations and deload weeks
- Remove preset HIIT day reps/sets and enhance HIIT generator with workout type, time caps, AMRAP option, and scaling note
- Update script references for cache busting

## Testing
- `npm test` *(fails: package.json missing)*
- `node --check src/js/plan.js && node --check src/js/hiit.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4f79812e8832f9d27cc471578ed9a